### PR TITLE
Update SafeRoom.cs

### DIFF
--- a/Escape Bloodhill Unity/Assets/Scripts/JohnScripts/SafeRoom/SafeRoom.cs
+++ b/Escape Bloodhill Unity/Assets/Scripts/JohnScripts/SafeRoom/SafeRoom.cs
@@ -19,7 +19,7 @@ public class SafeRoom : MonoBehaviour
     void Start()
     {
         isIn = false;
-        storage = new GameObject[10];
+        storage = new GameObject[11];
         gameOverScreen = player.gameObject.GetComponent<PlayerHealth>().gameOverMenu;
     }
 


### PR DESCRIPTION
saferoom was only saving items after the player died once because the storage array initialized in Start() was one element short and causing an out of bounds error until the respawn code replaced it with one that matches the size of the inventory array